### PR TITLE
api_pse: Fix date time name for PSE api

### DIFF
--- a/optimshine/api_pse.py
+++ b/optimshine/api_pse.py
@@ -49,9 +49,9 @@ class ApiPse(ApiCommon):
             return False
 
         self.rce_date = date
-        self.rce_prices = {}
-        for quarter in response_data:
-            self.rce_prices.update({quarter["dtime"]: quarter["rce_pln"]})
+        self.rce_prices = {
+            quarter["dtime"]: quarter["rce_pln"] for quarter in response_data
+        }
 
         self.log.info(f"Successfully obtained RCE data for {self.rce_date}.")
         return True

--- a/optimshine/api_pse.py
+++ b/optimshine/api_pse.py
@@ -51,7 +51,7 @@ class ApiPse(ApiCommon):
         self.rce_date = date
         self.rce_prices = {}
         for quarter in response_data:
-            self.rce_prices.update({quarter["udtczas"]: quarter["rce_pln"]})
+            self.rce_prices.update({quarter["dtime"]: quarter["rce_pln"]})
 
         self.log.info(f"Successfully obtained RCE data for {self.rce_date}.")
         return True

--- a/tests/test_api_pse.py
+++ b/tests/test_api_pse.py
@@ -73,36 +73,42 @@ class TestPseApi(unittest.TestCase):
         mock_api_get_request.return_value = {
             "value": [
                 {
-                  "doba": "2025-05-14",
-                  "rce_pln": 439.58,
-                  "udtczas": "2025-05-14 00:15:00",
-                  "udtczas_oreb": "00:00 - 00:15",
-                  "business_date": "2025-05-14",
-                  "source_datetime": "2025-05-13 13:49:22.204"
+                    "dtime": "2025-06-16 00:15:00",
+                    "period": "00:00 - 00:15",
+                    "rce_pln": 439.58000,
+                    "dtime_utc": "2025-06-15 22:15:00",
+                    "period_utc": "22:00 - 22:15",
+                    "business_date": "2025-06-16",
+                    "publication_ts": "2025-06-15 13:44:11.203",
+                    "publication_ts_utc": "2025-06-15 11:44:11.203"
                 },
                 {
-                  "doba": "2025-05-14",
-                  "rce_pln": 449.58,
-                  "udtczas": "2025-05-14 00:30:00",
-                  "udtczas_oreb": "00:15 - 00:30",
-                  "business_date": "2025-05-14",
-                  "source_datetime": "2025-05-13 13:49:22.204"
+                    "dtime": "2025-06-16 00:30:00",
+                    "period": "00:15 - 00:30",
+                    "rce_pln": 449.58000,
+                    "dtime_utc": "2025-06-15 22:30:00",
+                    "period_utc": "22:15 - 22:30",
+                    "business_date": "2025-06-16",
+                    "publication_ts": "2025-06-15 13:44:11.203",
+                    "publication_ts_utc": "2025-06-15 11:44:11.203"
                 },
                 {
-                  "doba": "2025-05-14",
-                  "rce_pln": 459.58,
-                  "udtczas": "2025-05-14 00:45:00",
-                  "udtczas_oreb": "00:30 - 00:45",
-                  "business_date": "2025-05-14",
-                  "source_datetime": "2025-05-13 13:49:22.204"
+                    "dtime": "2025-06-16 00:45:00",
+                    "period": "00:30 - 00:45",
+                    "rce_pln": 459.58000,
+                    "dtime_utc": "2025-06-15 22:45:00",
+                    "period_utc": "22:30 - 22:45",
+                    "business_date": "2025-06-16",
+                    "publication_ts": "2025-06-15 13:44:11.203",
+                    "publication_ts_utc": "2025-06-15 11:44:11.203"
                 },
             ]
         }
         expected_date = "2025-05-14"
         expected_prices = {
-            "2025-05-14 00:15:00": 439.58,
-            "2025-05-14 00:30:00": 449.58,
-            "2025-05-14 00:45:00": 459.58,
+            "2025-06-16 00:15:00": 439.58,
+            "2025-06-16 00:30:00": 449.58,
+            "2025-06-16 00:45:00": 459.58,
         }
 
         cls_api_pse = api.ApiPse(self.log)


### PR DESCRIPTION
PSE recently has changed time name from udtczas to dtime. This fix changes the name of the PSE data field and modifies related test.